### PR TITLE
Systematic whole-package lint pass -- clear the standing lint-CI red

### DIFF
--- a/R/applyKinshipOverrides.R
+++ b/R/applyKinshipOverrides.R
@@ -2,19 +2,21 @@
 #'
 ## Copyright(c) 2017-2026 R. Mark Sharp
 ## This file is part of nprcgenekeepr
-#' Writes pairwise kinship coefficients from outside information (issue #13) into
-#' a computed kinship matrix, replacing the pedigree-derived value for the named
-#' pairs. Each \code{(id1, id2, kinship)} row sets both \code{kmat[id1, id2]} and
-#' its symmetric twin \code{kmat[id2, id1]}; all other cells are unchanged. This
-#' is a direct cell replacement -- it does not propagate to descendant rows.
+#' Writes pairwise kinship coefficients from outside information
+#' (issue #13) into a computed kinship matrix, replacing the
+#' pedigree-derived value for the named pairs. Each
+#' \code{(id1, id2, kinship)} row sets both \code{kmat[id1, id2]} and its
+#' symmetric twin \code{kmat[id2, id1]}; all other cells are unchanged.
+#' This is a direct cell replacement -- it does not propagate to descendant
+#' rows.
 #'
 #' \code{kmat} must be a dense, symmetric, id-named base R matrix (the object
 #' \code{\link{kinship}} returns); a sparse \code{Matrix} object is out of
 #' contract. The function is strict: it \code{stop()}s on an id absent from the
 #' matrix and on a value above the exact positive-semi-definiteness bound
-#' \code{sqrt(kmat[id1, id1] * kmat[id2, id2])}. Soft, run-preserving handling of
-#' ids outside the analysis set is the caller's responsibility --
-#' \code{\link{reportGV}} warn-drops non-member ids before calling this.
+#' \code{sqrt(kmat[id1, id1] * kmat[id2, id2])}. Soft, run-preserving
+#' handling of ids outside the analysis set is the caller's responsibility
+#' -- \code{\link{reportGV}} warn-drops non-member ids before calling this.
 #' \code{kinship()} itself is never modified (it has several callers, including
 #' two simulations that must not take current-kinship overrides).
 #'
@@ -42,7 +44,7 @@ applyKinshipOverrides <- function(kmat, overrides) {
   unknown <- setdiff(unique(c(overrides$id1, overrides$id2)), ids)
   if (length(unknown) > 0L) {
     stop("Kinship override id(s) not found in the matrix: ",
-      paste(unknown, collapse = ", "), ".")
+      toString(unknown), ".")
   }
 
   for (i in seq_len(nrow(overrides))) {

--- a/R/applyKinshipOverridesToMatrix.R
+++ b/R/applyKinshipOverridesToMatrix.R
@@ -25,7 +25,7 @@ applyKinshipOverridesToMatrix <- function(kmat, overrides) {
   }
   inMatrix <- overrides$id1 %in% rownames(kmat) &
     overrides$id2 %in% rownames(kmat)
-  if (any(!inMatrix)) {
+  if (!all(inMatrix)) {
     dropped <- setdiff(
       unique(c(overrides$id1[!inMatrix], overrides$id2[!inMatrix])),
       rownames(kmat)
@@ -33,7 +33,7 @@ applyKinshipOverridesToMatrix <- function(kmat, overrides) {
     warning(sprintf(
       paste0("Dropping %d kinship override row(s) referencing id(s) not in ",
         "the analysis set: %s."),
-      sum(!inMatrix), paste(dropped, collapse = ", ")
+      sum(!inMatrix), toString(dropped)
     ))
     overrides <- overrides[inMatrix, , drop = FALSE]
   }

--- a/R/calcFEFG.R
+++ b/R/calcFEFG.R
@@ -10,11 +10,12 @@
 #' mean contributions to the current descendants and \code{r} is the mean
 #' number of founder alleles retained in the gene dropping experiment.
 #'
-#' \code{FE} is deterministic and always returned. \code{FG} is \code{NA} (with a
-#' warning) when a contributing founder (\code{p > 0}) is retained in zero of the
-#' gene-drop iterations (\code{r == 0}), which would otherwise collapse \code{FG}
-#' silently to 0; raise the number of iterations. See \code{\link{calcFGSE}} for
-#' the sampling standard error of \code{FG}.
+#' \code{FE} is deterministic and always returned. \code{FG} is \code{NA}
+#' (with a warning) when a contributing founder (\code{p > 0}) is retained
+#' in zero of the gene-drop iterations (\code{r == 0}), which would
+#' otherwise collapse \code{FG} silently to 0; raise the number of
+#' iterations. See \code{\link{calcFGSE}} for the sampling standard error
+#' of \code{FG}.
 #'
 #' @param ped the pedigree information in datatable format.  Pedigree
 #' (req. fields: id, sire, dam, gen, population).
@@ -62,8 +63,8 @@ calcFEFG <- function(ped, alleles) {
   ## unaffected by the ordering.
   r <- r[names(fc$p)]
   fe <- 1L / sum(fc$p^2L)
-  ## FE is deterministic and always returned; FG hard-fails (NA + warning) on the
-  ## same zero-retention silent collapse calcFG guards against.
+  ## FE is deterministic and always returned; FG hard-fails (NA + warning)
+  ## on the same zero-retention silent collapse calcFG guards against.
   if (checkFgDegeneracy(fc$p, r)) {
     return(list(FE = fe, FG = NA_real_))
   }

--- a/R/calcFG.R
+++ b/R/calcFG.R
@@ -9,11 +9,12 @@
 #' mean contributions to the current descendants and \code{r} is the mean
 #' number of founder alleles retained in the gene dropping experiment.
 #'
-#' Returns \code{NA} with a warning when a contributing founder (\code{p > 0}) is
-#' retained in zero of the gene-drop iterations (\code{r == 0}): that term is
-#' \code{p^2 / 0 = Inf}, which would otherwise collapse \code{FG} silently to 0.
-#' Raise the number of iterations. See \code{\link{calcFGSE}} for the sampling
-#' standard error of \code{FG}.
+#' Returns \code{NA} with a warning when a contributing founder
+#' (\code{p > 0}) is retained in zero of the gene-drop iterations
+#' (\code{r == 0}): that term is \code{p^2 / 0 = Inf}, which would
+#' otherwise collapse \code{FG} silently to 0. Raise the number of
+#' iterations. See \code{\link{calcFGSE}} for the sampling standard error
+#' of \code{FG}.
 #'
 #' @param ped the pedigree information in datatable format.  Pedigree
 #' (req. fields: id, sire, dam, gen, population).
@@ -67,8 +68,8 @@ calcFG <- function(ped, alleles) {
   ## Align retention to contributions by NAME before dividing (issue #86,
   ## Dragon D-3): calcRetention() returns r id-sorted (tapply) while fc$p is in
   ## getFounders() pedigree-row order, so a positional p^2 / r pairs the wrong
-  ## founders -- a silently wrong FG (e.g. a collapse to 0) on any pedigree whose
-  ## founders are not already in sorted id order.
+  ## founders -- a silently wrong FG (e.g. a collapse to 0) on any pedigree
+  ## whose founders are not already in sorted id order.
   r <- r[names(fc$p)]
   ## Hard-fail (NA + warning) the silent FG collapse when a contributing founder
   ## is retained in zero drops; the point estimate is unchanged otherwise.

--- a/R/calcFGSE.R
+++ b/R/calcFGSE.R
@@ -23,17 +23,19 @@
 #' founder-by-founder covariance matrix.
 #'
 #' Founders are matched between \code{p} and \code{r} by name (not position), so
-#' the result is correct even when the founders are not in sorted pedigree order.
+#' the result is correct even when the founders are not in sorted pedigree
+#' order.
 #'
 #' A contributing founder (\code{p > 0}) that is retained in zero of the
-#' iterations (\code{r == 0}) makes \code{FG} undefined (the same degeneracy that
-#' \code{\link{calcFG}} now reports as \code{NA}); in that case this function
-#' returns \code{NA} with a warning advising more iterations. Founders that do
-#' not contribute to the current population (\code{p == 0}) are dropped, so the
-#' standard error refers to exactly the founder set \code{FG} is computed from.
+#' iterations (\code{r == 0}) makes \code{FG} undefined (the same
+#' degeneracy that \code{\link{calcFG}} now reports as \code{NA}); in that
+#' case this function returns \code{NA} with a warning advising more
+#' iterations. Founders that do not contribute to the current population
+#' (\code{p == 0}) are dropped, so the standard error refers to exactly the
+#' founder set \code{FG} is computed from.
 #'
-#' @return A single numeric value: the Monte Carlo sampling standard error of the
-#' colony founder-genome-equivalent estimate, on the same scale as
+#' @return A single numeric value: the Monte Carlo sampling standard error
+#' of the colony founder-genome-equivalent estimate, on the same scale as
 #' \code{\link{calcFG}}. \code{NA} (with a warning) when a contributing founder
 #' has zero retention.
 #'
@@ -78,15 +80,16 @@ calcFGSE <- function(ped, alleles) {
   p <- fc$p[names(rhat)] # align contributions to retention rows by NAME
   k <- ncol(retentionMatrix)
 
-  ## Hard-fail: a contributing founder retained in zero drops leaves FG (and its
-  ## gradient) undefined -- return NA rather than a finite SE for a collapsed FG.
+  ## Hard-fail: a contributing founder retained in zero drops leaves FG
+  ## (and its gradient) undefined -- return NA rather than a finite SE for
+  ## a collapsed FG.
   if (checkFgDegeneracy(p, rhat)) {
     return(NA_real_)
   }
 
   ## Drop non-contributing (p == 0 -> 0/0) and any missing-retention founders so
   ## the SE refers to the same founder set as FG.
-  keep <- !is.na(rhat) & rhat > 0 & !is.na(p)
+  keep <- !is.na(rhat) & rhat > 0L & !is.na(p)
   fg <- 1L / sum((p[keep]^2L) / rhat[keep])
   gradient <- numeric(length(rhat))
   gradient[keep] <- fg^2L * (p[keep]^2L) / (rhat[keep]^2L)

--- a/R/checkFgDegeneracy.R
+++ b/R/checkFgDegeneracy.R
@@ -20,7 +20,7 @@
 #' @noRd
 checkFgDegeneracy <- function(p, r) {
   r <- r[names(p)] # align retention to contributions by NAME (Dragon D-3)
-  if (any(!is.na(p) & p > 0 & !is.na(r) & r == 0)) {
+  if (any(!is.na(p) & p > 0L & !is.na(r) & r == 0L)) {
     warning(
       "Founder genome equivalents undefined: founder(s) with positive ",
       "contribution were retained in 0 of the gene-drop iterations; ",

--- a/R/checkKinshipOverrides.R
+++ b/R/checkKinshipOverrides.R
@@ -36,8 +36,8 @@ checkKinshipOverrides <- function(overrides) {
   missingCols <- setdiff(required, names(overrides))
   if (length(missingCols) > 0L) {
     stop("Kinship overrides must have columns ",
-      paste(required, collapse = ", "), "; missing: ",
-      paste(missingCols, collapse = ", "), ".")
+      toString(required), "; missing: ",
+      toString(missingCols), ".")
   }
   overrides$id1 <- as.character(overrides$id1)
   overrides$id2 <- as.character(overrides$id2)
@@ -45,10 +45,10 @@ checkKinshipOverrides <- function(overrides) {
   if (!is.numeric(overrides$kinship)) {
     stop("Kinship overrides 'kinship' column must be numeric.")
   }
-  if (any(is.na(overrides$kinship))) {
+  if (anyNA(overrides$kinship)) {
     stop("Kinship overrides 'kinship' column must not contain NA.")
   }
-  if (any(overrides$kinship < 0)) {
+  if (any(overrides$kinship < 0L)) {
     stop("Kinship overrides 'kinship' values must not be negative.")
   }
   if (any(overrides$id1 == overrides$id2)) {
@@ -61,7 +61,7 @@ checkKinshipOverrides <- function(overrides) {
   if (anyDuplicated(key) > 0L) {
     dup <- unique(key[duplicated(key)])
     stop("Kinship overrides contain duplicated (unordered) pair(s): ",
-      paste(gsub("\r", "-", dup), collapse = ", "), ".")
+      toString(gsub("\r", "-", dup, fixed = TRUE)), ".")
   }
   ## off-diagonal kinship for a non-inbred pair cannot exceed 0.5 (warn here;
   ## the exact per-pair bound is enforced in applyKinshipOverrides, D6)

--- a/R/modSummaryStats.R
+++ b/R/modSummaryStats.R
@@ -282,9 +282,10 @@ modSummaryStatsUI <- function(id) {
 #'   overrides are applied to that matrix, so the relationship table and the
 #'   kinship CSV export reflect the supplied values regardless of tab order.
 #'   The override moves the kinship \emph{value} only; the \code{relation}
-#'   \emph{label} stays pedigree-derived (it is computed from pedigree structure,
-#'   not from the kinship value). Overridden pairs are flagged with a logical
-#'   \code{overridden} column in the relationship table (issue #13 item-3).
+#'   \emph{label} stays pedigree-derived (it is computed from pedigree
+#'   structure, not from the kinship value). Overridden pairs are flagged
+#'   with a logical \code{overridden} column in the relationship table
+#'   (issue #13 item-3).
 #'   \code{NULL} (the default) is a no-op.
 #'
 #' @seealso \code{\link{modSummaryStatsUI}} for the user interface
@@ -364,14 +365,16 @@ modSummaryStatsServer <- function(id, geneticValues, pedigree,
         }
       }
 
-      # Calculate kinship from pedigree if not provided (the fallback recompute,
-      # the path the app always takes since appServer passes kinshipMatrix=NULL).
+      # Calculate kinship from pedigree if not provided (the fallback
+      # recompute, the path the app always takes since appServer passes
+      # kinshipMatrix=NULL).
       # Issue #13 Slice 3: apply outside-information kinship overrides to this
       # matrix so the relationship table and the kinship CSV export reflect them
       # regardless of tab order. The passed-kinshipMatrix branch above already
       # carries overrides. Ids absent from the matrix are warn-dropped, never
       # aborting the module (D5). The override moves the kinship VALUE; the
-      # relation LABEL stays pedigree-derived (convertRelationships is structural).
+      # relation LABEL stays pedigree-derived (convertRelationships is
+      # structural).
       if (!"gen" %in% names(ped)) {
         ped$gen <- findGeneration(ped$id, ped$sire, ped$dam)
       }

--- a/R/reportGV.R
+++ b/R/reportGV.R
@@ -62,11 +62,11 @@
 #' overrides (\code{id1}, \code{id2}, \code{kinship}; the coefficient \emph{f},
 #' not relatedness \emph{r}) applied to the kinship matrix before mean kinship
 #' and the unknown-parent correction (issue #13). \code{NULL} (the default)
-#' leaves the pedigree-derived matrix unchanged. Ids outside the analysis set are
-#' warn-dropped (the run is not aborted). An override REFINES the named kinship
-#' cell; it does not suppress the \code{+ sexMean / 2} unknown-parent
-#' correction, which is kept for every animal missing one parent (issue #95
-#' keep-all revert). See \code{\link{applyKinshipOverrides}}.
+#' leaves the pedigree-derived matrix unchanged. Ids outside the analysis
+#' set are warn-dropped (the run is not aborted). An override REFINES the
+#' named kinship cell; it does not suppress the \code{+ sexMean / 2}
+#' unknown-parent correction, which is kept for every animal missing one
+#' parent (issue #95 keep-all revert). See \code{\link{applyKinshipOverrides}}.
 #' @export
 #' @examples
 #' library(nprcgenekeepr)

--- a/data-raw/fgSEValidation.R
+++ b/data-raw/fgSEValidation.R
@@ -1,7 +1,7 @@
-## Issue #82 Slice 2 -- recorded validation study for calcFGSE() (the founder-
+## Issue #82 Slice 2 -- recorded validation study for calcFGSE (the founder-
 ## genome-equivalent sampling SE). This is the "validate before expose" gate:
-## the SE must be shown calibrated on a REAL deep/bottlenecked pedigree before it
-## is surfaced to users (Slice 3). The seven checks (agreement, coverage,
+## the SE must be shown calibrated on a REAL deep/bottlenecked pedigree before
+## it is surfaced to users (Slice 3). The seven checks (agreement, coverage,
 ## 1/sqrt(K) scaling, degeneracy audit, off-diagonal materiality, bootstrap
 ## cross-check) follow plan docs/planning/issue82-fg-se-plan.md Section 2 / 6.
 ##
@@ -11,12 +11,15 @@
 ## to data-raw/fgSEValidation-results.rds; the table embedded in
 ## vignettes/articles/fg-se-validation.qmd is this script's printed summary.
 ##
-## The harness functions (fgSEValidate etc.) live in the test helpers so the test
-## suite unit-tests them on synthetic input; this runner drives the slow study.
+## The harness functions (fgSEValidate etc.) live in the test helpers so the
+## test suite unit-tests them on synthetic input; this runner drives the
+## slow study.
 
 suppressMessages(pkgload::load_all(".", quiet = TRUE))
-source("tests/testthat/helper-fgSEFixtures.R")
-source("tests/testthat/helper-fgSEValidation.R")
+# nolint start: undesirable_function_linter.
+source(file.path("tests", "testthat", "helper-fgSEFixtures.R"))
+source(file.path("tests", "testthat", "helper-fgSEValidation.R"))
+# nolint end
 
 B <- 300L
 seeds <- seq_len(B)
@@ -31,7 +34,7 @@ lacyPed <- nprcgenekeepr::lacy1989Ped
 ## with r < 0.10), assembled exactly as reportGV() analyzes it.
 data("examplePedigree")
 breederPed <- qcStudbook(examplePedigree,
-  minParentAge = 2, reportChanges = FALSE, reportErrors = FALSE
+  minParentAge = 2L, reportChanges = FALSE, reportErrors = FALSE
 )
 focal <- breederPed$id[!(is.na(breederPed$sire) & is.na(breederPed$dam)) &
   is.na(breederPed$exit)]
@@ -43,11 +46,15 @@ exPed <- trimPedigree(probands, exPed,
 exPed$population <- getGVPopulation(exPed, NULL)
 
 message("Running lacy1989 (B=", B, ", K=", K, ") ...")
+# nolint start: implicit_assignment_linter.
 tLacy <- system.time(resLacy <- fgSEValidate(lacyPed, seeds = seeds, k = K))
+# nolint end
 message("  ", round(tLacy[["elapsed"]]), "s")
 
 message("Running examplePedigree (B=", B, ", K=", K, ") ...")
+# nolint start: implicit_assignment_linter.
 tEx <- system.time(resEx <- fgSEValidate(exPed, seeds = seeds, k = K))
+# nolint end
 message("  ", round(tEx[["elapsed"]]), "s")
 
 results <- list(
@@ -55,7 +62,7 @@ results <- list(
   B = B, K = K, generated = "2026-06-26",
   elapsed = c(lacy1989 = tLacy[["elapsed"]], examplePedigree = tEx[["elapsed"]])
 )
-saveRDS(results, "data-raw/fgSEValidation-results.rds")
+saveRDS(results, file.path("data-raw", "fgSEValidation-results.rds"))
 
 ## ---- printed summary (the numbers embedded in the article) ----
 fmtSummary <- function(res, label) {
@@ -65,16 +72,16 @@ fmtSummary <- function(res, label) {
   cat(sprintf("\n== %s (B=%d, K=%d) ==\n", label, s$B, s$k))
   cat(sprintf("  agreement  mean(SE)/sd(FG) = %.4f   [0.92,1.08]  %s\n",
     s$agreementRatio, yn(v$agreement)))
-  cat(sprintf("  coverage   frac FG+-1.96SE covers ref = %.4f   [0.93,0.97]  %s\n",
-    s$coverage, yn(v$coverage)))
+  cat(sprintf(paste0("  coverage   frac FG+-1.96SE covers ref = %.4f   ",
+    "[0.93,0.97]  %s\n"), s$coverage, yn(v$coverage)))
   cat(sprintf("  scaling    emp=%.3f delta=%.3f   [1.8,2.2]  %s\n",
     s$scalingEmp, s$scalingDelta, yn(v$scaling)))
   cat(sprintf("  degeneracy fraction any(p>0 & r=0) = %.4f   ==0  %s\n",
     s$degeneracyFraction, yn(v$degeneracy)))
-  cat(sprintf("  bootstrap  boot/delta = %.4f (dropped %.4f)   [0.85,1.15]  %s\n",
-    s$bootstrapRatio, s$bootDropped, yn(v$bootstrap)))
-  cat(sprintf("  off-diag   seFull=%.5g seDiag=%.5g  full/diag=%.3f (reported)\n",
-    s$seFull, s$seDiag, s$offDiagRatio))
+  fmtB <- "  bootstrap  boot/delta = %.4f (dropped %.4f)   [0.85,1.15]  %s\n"
+  cat(sprintf(fmtB, s$bootstrapRatio, s$bootDropped, yn(v$bootstrap)))
+  cat(sprintf(paste0("  off-diag   seFull=%.5g seDiag=%.5g  ",
+    "full/diag=%.3f (reported)\n"), s$seFull, s$seDiag, s$offDiagRatio))
   cat(sprintf("  refFG(K=%d)=%.5g   VERDICT: %s\n",
     s$refK, s$refFG, yn(v$overall)))
 }

--- a/man/applyKinshipOverrides.Rd
+++ b/man/applyKinshipOverrides.Rd
@@ -17,20 +17,22 @@ applyKinshipOverrides(kmat, overrides)
 \code{kmat} with the override cells replaced (symmetric).
 }
 \description{
-Writes pairwise kinship coefficients from outside information (issue #13) into
-a computed kinship matrix, replacing the pedigree-derived value for the named
-pairs. Each \code{(id1, id2, kinship)} row sets both \code{kmat[id1, id2]} and
-its symmetric twin \code{kmat[id2, id1]}; all other cells are unchanged. This
-is a direct cell replacement -- it does not propagate to descendant rows.
+Writes pairwise kinship coefficients from outside information
+(issue #13) into a computed kinship matrix, replacing the
+pedigree-derived value for the named pairs. Each
+\code{(id1, id2, kinship)} row sets both \code{kmat[id1, id2]} and its
+symmetric twin \code{kmat[id2, id1]}; all other cells are unchanged.
+This is a direct cell replacement -- it does not propagate to descendant
+rows.
 }
 \details{
 \code{kmat} must be a dense, symmetric, id-named base R matrix (the object
 \code{\link{kinship}} returns); a sparse \code{Matrix} object is out of
 contract. The function is strict: it \code{stop()}s on an id absent from the
 matrix and on a value above the exact positive-semi-definiteness bound
-\code{sqrt(kmat[id1, id1] * kmat[id2, id2])}. Soft, run-preserving handling of
-ids outside the analysis set is the caller's responsibility --
-\code{\link{reportGV}} warn-drops non-member ids before calling this.
+\code{sqrt(kmat[id1, id1] * kmat[id2, id2])}. Soft, run-preserving
+handling of ids outside the analysis set is the caller's responsibility
+-- \code{\link{reportGV}} warn-drops non-member ids before calling this.
 \code{kinship()} itself is never modified (it has several callers, including
 two simulations that must not take current-kinship overrides).
 }

--- a/man/calcFEFG.Rd
+++ b/man/calcFEFG.Rd
@@ -23,11 +23,12 @@ The list containing the founder equivalents,
 mean contributions to the current descendants and \code{r} is the mean
 number of founder alleles retained in the gene dropping experiment.
 
-\code{FE} is deterministic and always returned. \code{FG} is \code{NA} (with a
-warning) when a contributing founder (\code{p > 0}) is retained in zero of the
-gene-drop iterations (\code{r == 0}), which would otherwise collapse \code{FG}
-silently to 0; raise the number of iterations. See \code{\link{calcFGSE}} for
-the sampling standard error of \code{FG}.
+\code{FE} is deterministic and always returned. \code{FG} is \code{NA}
+(with a warning) when a contributing founder (\code{p > 0}) is retained
+in zero of the gene-drop iterations (\code{r == 0}), which would
+otherwise collapse \code{FG} silently to 0; raise the number of
+iterations. See \code{\link{calcFGSE}} for the sampling standard error
+of \code{FG}.
 }
 \description{
 Part of the Genetic Value Analysis

--- a/man/calcFG.Rd
+++ b/man/calcFG.Rd
@@ -21,11 +21,12 @@ The founder genome equivalents,
 mean contributions to the current descendants and \code{r} is the mean
 number of founder alleles retained in the gene dropping experiment.
 
-Returns \code{NA} with a warning when a contributing founder (\code{p > 0}) is
-retained in zero of the gene-drop iterations (\code{r == 0}): that term is
-\code{p^2 / 0 = Inf}, which would otherwise collapse \code{FG} silently to 0.
-Raise the number of iterations. See \code{\link{calcFGSE}} for the sampling
-standard error of \code{FG}.
+Returns \code{NA} with a warning when a contributing founder
+(\code{p > 0}) is retained in zero of the gene-drop iterations
+(\code{r == 0}): that term is \code{p^2 / 0 = Inf}, which would
+otherwise collapse \code{FG} silently to 0. Raise the number of
+iterations. See \code{\link{calcFGSE}} for the sampling standard error
+of \code{FG}.
 }
 \description{
 Part of the Genetic Value Analysis

--- a/man/calcFGSE.Rd
+++ b/man/calcFGSE.Rd
@@ -17,8 +17,8 @@ column, a \code{parent} column, and one column per gene-drop iteration.
 Produced by \code{geneDrop()}; the same input \code{\link{calcFG}} takes.}
 }
 \value{
-A single numeric value: the Monte Carlo sampling standard error of the
-colony founder-genome-equivalent estimate, on the same scale as
+A single numeric value: the Monte Carlo sampling standard error
+of the colony founder-genome-equivalent estimate, on the same scale as
 \code{\link{calcFG}}. \code{NA} (with a warning) when a contributing founder
 has zero retention.
 }
@@ -45,14 +45,16 @@ is used because it folds in that covariance automatically and never forms the
 founder-by-founder covariance matrix.
 
 Founders are matched between \code{p} and \code{r} by name (not position), so
-the result is correct even when the founders are not in sorted pedigree order.
+the result is correct even when the founders are not in sorted pedigree
+order.
 
 A contributing founder (\code{p > 0}) that is retained in zero of the
-iterations (\code{r == 0}) makes \code{FG} undefined (the same degeneracy that
-\code{\link{calcFG}} now reports as \code{NA}); in that case this function
-returns \code{NA} with a warning advising more iterations. Founders that do
-not contribute to the current population (\code{p == 0}) are dropped, so the
-standard error refers to exactly the founder set \code{FG} is computed from.
+iterations (\code{r == 0}) makes \code{FG} undefined (the same
+degeneracy that \code{\link{calcFG}} now reports as \code{NA}); in that
+case this function returns \code{NA} with a warning advising more
+iterations. Founders that do not contribute to the current population
+(\code{p == 0}) are dropped, so the standard error refers to exactly the
+founder set \code{FG} is computed from.
 }
 \examples{
 library(nprcgenekeepr)

--- a/man/modSummaryStatsServer.Rd
+++ b/man/modSummaryStatsServer.Rd
@@ -39,9 +39,10 @@ When the module recomputes kinship from the pedigree (the usual path), the
 overrides are applied to that matrix, so the relationship table and the
 kinship CSV export reflect the supplied values regardless of tab order.
 The override moves the kinship \emph{value} only; the \code{relation}
-\emph{label} stays pedigree-derived (it is computed from pedigree structure,
-not from the kinship value). Overridden pairs are flagged with a logical
-\code{overridden} column in the relationship table (issue #13 item-3).
+\emph{label} stays pedigree-derived (it is computed from pedigree
+structure, not from the kinship value). Overridden pairs are flagged
+with a logical \code{overridden} column in the relationship table
+(issue #13 item-3).
 \code{NULL} (the default) is a no-op.}
 }
 \value{

--- a/man/reportGV.Rd
+++ b/man/reportGV.Rd
@@ -61,11 +61,11 @@ species absent from the table. \code{NULL} uses the built-in 210 days.}
 overrides (\code{id1}, \code{id2}, \code{kinship}; the coefficient \emph{f},
 not relatedness \emph{r}) applied to the kinship matrix before mean kinship
 and the unknown-parent correction (issue #13). \code{NULL} (the default)
-leaves the pedigree-derived matrix unchanged. Ids outside the analysis set are
-warn-dropped (the run is not aborted). An override REFINES the named kinship
-cell; it does not suppress the \code{+ sexMean / 2} unknown-parent
-correction, which is kept for every animal missing one parent (issue #95
-keep-all revert). See \code{\link{applyKinshipOverrides}}.}
+leaves the pedigree-derived matrix unchanged. Ids outside the analysis
+set are warn-dropped (the run is not aborted). An override REFINES the
+named kinship cell; it does not suppress the \code{+ sexMean / 2}
+unknown-parent correction, which is kept for every animal missing one
+parent (issue #95 keep-all revert). See \code{\link{applyKinshipOverrides}}.}
 }
 \value{
 An object of class \code{nprcgenekeeprGV}: a list with elements


### PR DESCRIPTION
## Systematic whole-package lint pass

Clears the standing `lint`-CI red (the `lint.yaml` job, which errors because
`LINTR_ERROR_ON_LINT: true` turns any lint into a non-zero exit). Style /
readability only -- no behavior change.

### What changed
Addresses the 43 real `lintr` findings from the CI `lint_package()` run across
10 files (3 lint-batch commits + 1 man-page regen). The 31 `object_usage_linter`
entries that `lint_package()` shows locally are namespace artifacts -- they
vanish when the package is loaded, and CI installs the package via `local::.`,
so they never appear there -- and are left untouched.

All swaps are behavior-preserving:
- line_length: reflow long comment / roxygen lines (and split or bind long
  `sprintf` format strings, printed output unchanged)
- `paste(., collapse = ", ")` -> `toString(.)`
- `any(is.na(x))` -> `anyNA(x)`
- implicit `0` / `2` -> `0L` / `2L`
- `any(!x)` -> `!all(x)`
- `gsub("\r", ...)` -> `fixed = TRUE`
- `nonportable_path` -> `file.path()`
- `data-raw/fgSEValidation.R` (build-ignored dev runner): mechanical
  corrections; the `source()`-test-helpers and `system.time(x <- ...)` timing
  idioms get justified `# nolint` ranges (splitting either would be wrong --
  sourcing test helpers is correct, and `system.time(x <- ...)` both times and
  captures an ~11-min study)

`man/*.Rd` for the 6 reflowed exported-function files are regenerated
(whitespace-only; rendered help unchanged).

### Verification
- whole-package `lint_package()` (package loaded): 0 lints
- full test suite: 3173 pass / 0 fail / 0 error (7 pre-existing baseline-noise warnings)
- `devtools::check(vignettes = FALSE)`: 0 errors / 0 warnings / 0 notes
